### PR TITLE
Skip unnecessary columns by latest row value.

### DIFF
--- a/app/models/event/border.rb
+++ b/app/models/event/border.rb
@@ -13,14 +13,14 @@ class Event::Border
     res = InfluxDB::Rails.client.query "SELECT * FROM \"#{@series_name}\" LIMIT 1;"
     series_datas = res.values
     target_series_data = series_datas.first
-    raw_columns = target_series_data.first.keys
+    raw_columns = target_series_data.first
 
-    border_columns = raw_columns.select { |c| c.include? 'border_' }.sort { |a, b| a.match(/(\d+)/).to_s.to_i <=> b.match(/(\d+)/).to_s.to_i }
-    other_columns = raw_columns.select do |column|
-      !(column.include?('border_') || @@meta_columns.include?(column))
+    border_columns = raw_columns.select { |k, v| k.include?('border_') && !v.nil? }.keys.sort { |a, b| a.match(/(\d+)/).to_s.to_i <=> b.match(/(\d+)/).to_s.to_i }
+    other_columns = raw_columns.select do |k, v|
+      !(k.include?('border_') || @@meta_columns.include?(k) || v.nil?)
     end
 
-    @columns = border_columns.concat other_columns
+    @columns = border_columns.concat other_columns.keys
   end
 
   def progress


### PR DESCRIPTION
# Overview
Cause complicated reason, we have unnecessary column(s) by inserting influxdb.

![Unnecessary column (border_500)](https://cloud.githubusercontent.com/assets/1079365/8075198/4db98a82-0f78-11e5-8700-073a78f6227c.png)

The unnecessary columns take always `nil` value, our `Event::Border` model ignore the columns that seem "unnecessary".

![Skip unnecessary column](https://cloud.githubusercontent.com/assets/1079365/8075234/a96baf0e-0f78-11e5-8cbe-1df6ceb6d9f8.png)
