### PR TITLE
Fix bug.

### DIFF
--- a/app/views/events/_am_charts.html.erb
+++ b/app/views/events/_am_charts.html.erb
@@ -27,7 +27,7 @@
         if (value == 0) return 0;
         var s = ['', '万', '億'];
         var e = Math.floor(Math.log(value) / Math.log(10000));
-        return (value / Math.pow(10000, e)).toFixed(0) + s[e];
+        return parseFloat((value / Math.pow(10000, e)).toFixed(1)) + s[e];
       },
       "position": "left"
     }],


### PR DESCRIPTION
When points are over 100 Million, we should show after the decimal
point. Or we can't distinguish each of 1.0 [100 million] and 1.x [100
million].