### PR TITLE
Migration for influxdb 0.9.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,4 +68,4 @@ group :test do
 end
 
 gem 'influxdb-rails'
-gem 'influxdb', '~> 0.1.0'
+gem 'influxdb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       activesupport (>= 4.1.0)
     hashie (3.4.3)
     i18n (0.7.0)
-    influxdb (0.1.9)
+    influxdb (0.2.3)
       cause
       json
     influxdb-rails (0.1.10)
@@ -210,7 +210,7 @@ DEPENDENCIES
   database_rewinder
   factory_girl_rails
   font-awesome-sass
-  influxdb (~> 0.1.0)
+  influxdb
   influxdb-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -66,6 +66,10 @@ class Event < ActiveRecord::Base
     end
   end
 
+  def default_series_name
+    "#{self.started_at.strftime('%Y%m%d')}-#{self.ended_at.strftime('%Y%m%d')}_#{self.event_type.sub('_event', '')}"
+  end
+
   def self.at(time = Time.now)
     time = Time.parse(time) if time.class == String
     where(arel_table[:started_at].lteq(time)).


### PR DESCRIPTION
Migrate influxDB to newer version.

- https://influxdb.com/docs/v0.9/introduction/overview.html
- https://github.com/influxdb/influxdb-ruby/tree/v0.2.3